### PR TITLE
Update to have currentTerm routes and fixed unavailable rooms not showing 

### DIFF
--- a/v2/backend/helpers.ts
+++ b/v2/backend/helpers.ts
@@ -9,7 +9,7 @@ import { ScraperData, BuildingDatabase } from "./types";
 const API = "https://timetable.csesoc.app"
 
 const TERM_DATE_FETCH = `${API}/api/startdate/freerooms`;
-const TERM_ID_FETCH = `${API}/api/availableterm`;
+const TERM_ID_FETCH = `${API}/api/currentterm`;
 
 const TERM_ID_LENGTH = 2;
 const DATE_REGEX = /(\d{2})\/(\d{2})\/(\d{4})/;
@@ -95,8 +95,8 @@ export const scrapeBuildingData = async (): Promise<BuildingDatabase> => {
 export const getWeek = async (date: Date) => {
   // In 'DD/MM/YYYY' format
   const termStart = await getStartDate();
-
-  const termStartDate = new Date(termStart);
+  const [day, month, year] = termStart.split('/');
+  const termStartDate = new Date(+year, +month - 1, day);
   const today = date;
 
   const diff = today.getTime() - termStartDate.getTime();

--- a/v2/backend/index.ts
+++ b/v2/backend/index.ts
@@ -41,7 +41,6 @@ app.get(
     if (datetime === null) {
       throw new Error('Invalid date');
     }
-
     const roomData = await getAllRoomStatus(buildingID, datetime);
     const data = { rooms: roomData };
     res.send(data);

--- a/v2/backend/service.ts
+++ b/v2/backend/service.ts
@@ -58,13 +58,18 @@ export const getAllRoomStatus = async (
     let currTime = date.getTime();
     let isFree = true;
     for (const eachClass of scraperData[buildingID][roomNumber][week][day]) {
-      const classStart = new Date(eachClass["start"]).getTime();
-      const classEnd = new Date(eachClass["end"]).getTime();
+      let classStart = new Date(date.valueOf()); 
+      const [startHours, startMinutes] = eachClass["start"].split(':');
+      classStart.setHours(+startHours, +startMinutes);
 
-      if (currTime >= classStart && currTime < classEnd) {
+      let classEnd = new Date(date.valueOf()); 
+      const [endHours, endMinutes] = eachClass["end"].split(':');
+      classEnd.setHours(+endHours, +endMinutes);
+      
+      if (currTime >= classStart.getTime() && currTime < classEnd.getTime()) {
         isFree = false;
 
-        if (classEnd - currTime <= FIFTEEN_MIN) {
+        if (classEnd.getTime() - currTime <= FIFTEEN_MIN) {
           roomStatus[roomNumber] = {
             status: "soon",
             endtime: eachClass["end"],
@@ -75,7 +80,7 @@ export const getAllRoomStatus = async (
             endtime: eachClass["end"],
           };
         }
-        currTime = classEnd;
+        currTime = classEnd.getTime();
       }
     }
 


### PR DESCRIPTION
We used to use the availableTerm endpoint but this means in T2, it could be showing T3 because the T3 timetables are out. However, in freerooms, we would only like the currentTerm. 

Also, because of the changes in timetable-scraper, the room status would always show available. 