### PR TITLE
Rename backend endpoints

### DIFF
--- a/frontend/src/apiconfig.ts
+++ b/frontend/src/apiconfig.ts
@@ -11,4 +11,4 @@ const API_CONFIG: Record<string, string> = Object.freeze({
   [Env.PROD]: `${LIVE}`,
 });
 
-export const API_URL: string = API_CONFIG[process.env.NODE_ENV || Env.DEV];
+export const API_URL: string = API_CONFIG[process.env.NODE_ENV || Env.DEV] + "/api";

--- a/v2/backend/index.ts
+++ b/v2/backend/index.ts
@@ -22,7 +22,7 @@ const asyncHandler = (fn: RequestHandler) =>
 
 // Route to get all the buildings
 app.get(
-  "/buildings",
+  "/api/buildings",
   asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
     const buildingData = await getAllBuildings();
     const data = { buildings: buildingData };
@@ -33,7 +33,7 @@ app.get(
 
 // Route to get all the rooms in a particular building
 app.get(
-  "/buildings/:buildingID",
+  "/api/buildings/:buildingID",
   asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
     const { buildingID } = req.params;
 
@@ -86,7 +86,7 @@ app.get(
 
 // Route to get the availability of a particular room in a particular building
 app.get(
-  "/buildings/:buildingID/:roomNumber",
+  "/api/buildings/:buildingID/:roomNumber",
   asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
     const { buildingID, roomNumber } = req.params;
 
@@ -98,7 +98,7 @@ app.get(
 
 // Route to get status of all rooms
 app.get(
-  "/rooms",
+  "/api/rooms",
   asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
     const datetimeString = req.query.datetime as string;
     const datetime = datetimeString ? getDate(datetimeString) : new Date();
@@ -148,7 +148,7 @@ app.get(
 
 // Route to get the availability of a particular room in a particular building
 app.get(
-  "/rooms/:roomID",
+  "/api/rooms/:roomID",
   asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
     const { roomID } = req.params;
     const [campus, buildingGrid, roomNumber] = roomID.split('-');

--- a/v2/frontend/components/BuildingCard.tsx
+++ b/v2/frontend/components/BuildingCard.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import useSWR from "swr";
-import { server } from "../config";
+import { API_URL } from "../config";
 import { Building, BuildingStatus } from "../types";
 
 import Image, { ImageProps } from "next/image";

--- a/v2/frontend/config/index.ts
+++ b/v2/frontend/config/index.ts
@@ -11,4 +11,4 @@ const API_CONFIG: Record<string, string> = Object.freeze({
   [Env.PROD]: `${LIVE}`,
 });
 
-export const server: string = API_CONFIG[process.env.NODE_ENV || Env.DEV] + "/api";
+export const API_URL: string = API_CONFIG[process.env.NODE_ENV || Env.DEV] + "/api";

--- a/v2/frontend/config/index.ts
+++ b/v2/frontend/config/index.ts
@@ -1,5 +1,14 @@
-const dev = process.env.NODE_ENV !== "production";
+export enum Env {
+  DEV = "development",
+  PROD = "production",
+}
 
-export const server = dev
-  ? "http://localhost:3000"
-  : "https://freerooms.csesoc.app";
+const LOCAL = "http://localhost:3000";
+const LIVE = "https://freerooms.csesoc.app";
+
+const API_CONFIG: Record<string, string> = Object.freeze({
+  [Env.DEV]: `${LOCAL}`,
+  [Env.PROD]: `${LIVE}`,
+});
+
+export const server: string = API_CONFIG[process.env.NODE_ENV || Env.DEV] + "/api";

--- a/v2/frontend/pages/index.tsx
+++ b/v2/frontend/pages/index.tsx
@@ -3,7 +3,7 @@
 */
 
 import React from "react";
-import { server } from "../config";
+import { API_URL } from "../config";
 import { DateTime } from "luxon";
 import {
   RoomStatus,
@@ -74,7 +74,7 @@ const Home: NextPage<{ buildingData: BuildingReturnData }> = ({
     }
 
     axios
-      .get(server + "/rooms", { params: params })
+      .get(API_URL + "/rooms", { params: params })
       .then((res) => {
         setRoomStatusData(res.status == 200 ? res.data : {});
       })
@@ -190,9 +190,15 @@ const Home: NextPage<{ buildingData: BuildingReturnData }> = ({
 export async function getStaticProps() {
   // fetches /buildings via **BUILD** time so we don't need to have
   // the client fetch buildings data every request
-  const res = await fetch(server + "/buildings");
-  const buildings: BuildingReturnData = await res.json();
-  // const buildings: BuildingReturnData = { buildings: [] };
+  
+  let buildings: BuildingReturnData;
+  try {
+    const res = await fetch(API_URL + "/buildings");
+    buildings = await res.json();
+  } catch {
+    buildings = { buildings: [] };
+  }
+  
   return {
     props: {
       buildingData: buildings,

--- a/v2/frontend/views/BuildingInfo.tsx
+++ b/v2/frontend/views/BuildingInfo.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import axios from "axios";
 import useSWR from "swr";
-import { server } from "../config";
+import { API_URL } from "../config";
 import {
   RoomStatus,
   Building,


### PR DESCRIPTION
- Rename backend endpoints to begin with `/api` since apparently the v1 frontend has some `/rooms` route that conflicts with the new backend one
- Added a catch block for when the frontend tries to fetch buildings on build and fails (previously it would just fail build and prevent any backend changes from getting deployed)