### PR TITLE
fix: refactor to reflect new timetable scraper response format

### DIFF
--- a/frontend/src/services/dbService.ts
+++ b/frontend/src/services/dbService.ts
@@ -118,7 +118,6 @@ export default class DbService {
     endTime: string
   ) {
     // Gets all the room bookings from start time
-    const days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
     const data = await api.getRoomBookings(location, room, startTime);
 
     if (!data) {
@@ -150,28 +149,8 @@ export default class DbService {
         for (const booking of dayData) {
           if (!booking["start"] || !booking["end"]) continue;
 
-          const currentDay = startDate.getDate() + days.indexOf(day);
-          const hoursStart =
-            startDate.getHours() + parseInt(booking["start"].split(":")[0]);
-          const hoursEnd =
-            startDate.getHours() + parseInt(booking["end"].split(":")[0]);
-
-          const bookingStartDate = new Date(
-            startDate.getFullYear(),
-            startDate.getMonth(),
-            currentDay,
-            hoursStart,
-            0,
-            0
-          );
-          const bookingEndDate = new Date(
-            startDate.getFullYear(),
-            startDate.getMonth(),
-            currentDay,
-            hoursEnd,
-            0,
-            0
-          );
+          const bookingStartDate = new Date(booking['start']);
+          const bookingEndDate = new Date(booking['end']);
 
           const bookingEdit = booking;
           bookingEdit["start"] = DateTime.fromJSDate(bookingStartDate).toFormat(

--- a/v2/backend/src/helpers.ts
+++ b/v2/backend/src/helpers.ts
@@ -100,13 +100,13 @@ export const calculateStatus = (
   let firstAfter: Class | null = null;
   let secondAfter: Class | null = null;
   for (const cls of classes) {
-    const end = combineDateTime(datetime, cls.end);
+    const end = new Date(cls.end);
     if (end <= datetime) continue;
 
-    if (!firstAfter || end < combineDateTime(datetime, firstAfter.end)) {
+    if (!firstAfter || end < new Date(firstAfter.end)) {
       secondAfter = firstAfter;
       firstAfter = cls;
-    } else if (!secondAfter || end < combineDateTime(datetime, secondAfter.end)) {
+    } else if (!secondAfter || end < new Date(secondAfter.end)) {
       secondAfter = cls;
     }
   }
@@ -116,7 +116,7 @@ export const calculateStatus = (
     return roomStatus;
   }
 
-  const start = combineDateTime(datetime, firstAfter.start);
+  const start = new Date(firstAfter.start);
   if (datetime < start) {
     // Class starts after current time i.e. room is free, check if it meets minDuration filter
     const duration = (start.getTime() - datetime.getTime()) / (1000 * 60);
@@ -126,10 +126,10 @@ export const calculateStatus = (
     if (minDuration > 0) return null;
     roomStatus.status = "busy";
 
-    const end = combineDateTime(datetime, firstAfter.end);
+    const end = new Date(firstAfter.end);
     if (end.getTime() - datetime.getTime() <= FIFTEEN_MIN) {
       // Ending soon, check the next class
-      if (!secondAfter || combineDateTime(datetime, secondAfter.start) > end) {
+      if (!secondAfter || new Date(secondAfter.start) > end) {
         // No next class, or it starts after the current class ends
         roomStatus.status = "soon";
         roomStatus.endtime = end.toISOString();
@@ -138,17 +138,4 @@ export const calculateStatus = (
   }
 
   return roomStatus;
-}
-
-// Return a copy of provided date set to provided time
-// Time must be in the format HH:MM
-const combineDateTime = (date: Date, time: string) => {
-  if (!TIME_REGEX.test(time)) {
-    throw new Error("Invalid time format");
-  }
-
-  const newDate = new Date(date.valueOf());
-  const [hours, minutes] = time.split(':');
-  newDate.setHours(+hours, +minutes);
-  return newDate;
 }


### PR DESCRIPTION
The timetable scraper's return format had to be changed ([see PR](https://github.com/csesoc/timetable-scraper/pull/89)) in order to fix the bug causing times to be in the wrong timezone on staging.

This PR updates Freerooms' backend and v1 frontend to use this new format.