### PR TITLE
fix: use 100% height over 100vh so it works on mobile

### DIFF
--- a/v2/frontend/app/clientLayout.tsx
+++ b/v2/frontend/app/clientLayout.tsx
@@ -70,10 +70,10 @@ const Main = styled("main", {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.leavingScreen,
   }),
-  marginTop: navHeight,
+  paddingTop: navHeight,
   width: '100%',
   marginRight: 0,
-  maxHeight: "100vh",
+  height: "100%",
   ...(drawerOpen && {
     width: `calc(100% - ${drawerWidth}px)`,
     marginRight: drawerWidth,

--- a/v2/frontend/app/room/[room]/page.tsx
+++ b/v2/frontend/app/room/[room]/page.tsx
@@ -7,7 +7,6 @@ import React from 'react';
 
 import BookingCalendar from "../../../components/BookingCalendar";
 import LoadingCircle from "../../../components/LoadingCircle";
-import { navHeight } from "../../../components/NavBar";
 import useBookings from "../../../hooks/useBookings";
 import { setCurrentBuilding } from "../../../redux/currentBuildingSlice";
 import { useDispatch } from '../../../redux/hooks';
@@ -55,11 +54,11 @@ export default function Page({ params }: {
 
   return (
     
-    <Container maxWidth={false}>
+    <Container maxWidth={false} sx={{ height: "100%" }}>
       { !roomName
 				? <LoadingCircle/>
 				: (
-        <Stack justifyContent="center" alignItems="center" width="100%" py={5} height={`calc(100vh - ${navHeight}px)`}>
+        <Stack justifyContent="center" alignItems="center" width="100%" py={5} height="100%">
 	        <Typography variant='h4' fontWeight={550}>
 	          {roomName}
 	        </Typography>

--- a/v2/frontend/components/BookingCalendar.tsx
+++ b/v2/frontend/components/BookingCalendar.tsx
@@ -112,7 +112,7 @@ const StyledCalendar = styled(Calendar)(({ view }) => ({
 		margin: "1px !important"
 	},
 	'& .rbc-header': {
-		paddingY: 0.5,
+		padding: "5px 0",
 		fontSize: 16
 	},
 	'& .rbc-event-content': {

--- a/v2/frontend/components/Map.tsx
+++ b/v2/frontend/components/Map.tsx
@@ -14,7 +14,6 @@ import useUserLocation from "../hooks/useUserLocation";
 import { Building } from "../types";
 import calculateDistance from "../utils/calculateDistance";
 import MapMarker from "./MapMarker";
-import { navHeight } from "./NavBar";
 
 const center = {
   lat: -33.91767,
@@ -100,10 +99,9 @@ export const Map = () => {
 
   const renderMap = () => {
     return (
-      // 86.5 is the height of the header
-      <div style={{ position: "relative" }}>
+      <div style={{ position: "relative", height: "100%" }}>
         <GoogleMap
-          mapContainerStyle={{ height: `calc(100vh - ${navHeight}px)`, }}
+          mapContainerStyle={{ height: "100%", }}
           center={center}
           options={{
             clickableIcons: false,

--- a/v2/frontend/styles/globals.css
+++ b/v2/frontend/styles/globals.css
@@ -4,6 +4,7 @@ html,
 body {
     padding: 0;
     margin: 0;
+    height: 100%;
     font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 }


### PR DESCRIPTION
We've generally used `height: "100vh"` or `height: "calc(100vh - ${navHeight}px)"` to size the main the body of the site so that it fills the whole screen. However, on mobile `100vh` actually includes the browser search bar which is not part of the website (obviously), so it would overflow the screen and require you to scroll. Using `100%` avoids this problem.