### PR TITLE
chore(actions): replace deployment PAT with app dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,7 +63,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && (github.ref_name == 'dev' || github.ref_name == 'master')  }}
     steps:
       - name: Dispatch deployment
-        uses: devsoc-unsw/deployment-dispatch-action@a115e2ad9226805cd2588dc6fa5b7775991b141a
+        uses: devsoc-unsw/deployment-dispatch-action@main
         with:
           deployment-dispatcher-app-id: ${{ vars.DEPLOYMENT_DISPATCHER_APP_ID }}
           deployment-dispatcher-app-private-key: ${{ secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ github.token }}
       - name: Create staging .env file
         if: ${{ env.BRANCH_NAME == 'dev' && matrix.context == 'frontend' }}
         run: echo "NEXT_PUBLIC_STAGING=true" >> .env
@@ -62,27 +62,11 @@ jobs:
     concurrency: staging
     if: ${{ github.event_name != 'pull_request' && (github.ref_name == 'dev' || github.ref_name == 'master')  }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Dispatch deployment
+        uses: devsoc-unsw/deployment-dispatch-action@a115e2ad9226805cd2588dc6fa5b7775991b141a
         with:
-          repository: devsoc-unsw/deployment
-          token: ${{ secrets.GH_TOKEN }}
-          ref: dev
-      - name: Install yq - portable yaml processor
-        uses: mikefarah/yq@v4.44.3
-      - name: Update deployment
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          git config user.name "CSESoc CD"
-          git config user.email "technical@csesoc.org.au"
-
-          git checkout -b update/${{ env.IMAGE_NAME }}/${{ github.sha }}
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-backend:${{ github.sha }}"' projects/freerooms/${{ env.ENVIRONMENT }}/deploy-backend.yml
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-frontend:${{ github.sha }}"' projects/freerooms/${{ env.ENVIRONMENT }}/deploy-frontend.yml
-
-          git add . 
-          git commit -m "feat(${{ env.IMAGE_NAME }}): update images" 
-          git push -u origin update/${{ env.IMAGE_NAME }}/${{ github.sha }}
-          gh pr create -B dev --title "feat(${{ env.IMAGE_NAME }}): update image" --body "Updates the image for the ${{ env.IMAGE_NAME }} deployment to commit devsoc-unsw/${{ env.IMAGE_NAME }}@${{ github.sha }}." > URL
-          gh pr merge $(cat URL) --squash -d
+          deployment-dispatcher-app-id: ${{ vars.DEPLOYMENT_DISPATCHER_APP_ID }}
+          deployment-dispatcher-app-private-key: ${{ secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}
+          updates: |
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-backend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-frontend=${{ github.sha }}


### PR DESCRIPTION
## Summary
Use the shared `deployment-dispatch-action` in `.github/workflows/docker.yml` instead of directly checking out and editing `devsoc-unsw/deployment` from this repo's workflow.

## Changes
- replace the current deploy step flow with `devsoc-unsw/deployment-dispatch-action@main`
- rename the app credentials to `vars.DEPLOYMENT_DISPATCHER_APP_ID` and `secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY`
- switch GHCR publish authentication to `github.token`
- remove all remaining `GH_TOKEN` and old `IMAGE_UPDATER_*` references from the repo
- keep the existing workflow shape, runner selection, and action versions unless a change was required to remove `GH_TOKEN` or preserve `packages: write` for GHCR publishing

## Context
The action repository currently exposes `main` but does not expose a `v1` tag or `v1` branch, so this PR uses `@main` rather than a pinned commit SHA.

## Verification
- `yq eval '.' .github/workflows/docker.yml > /dev/null`
- `rg -n "\bGH_TOKEN\b|\bIMAGE_UPDATER_APP_ID\b|\bIMAGE_UPDATER_APP_PRIVATE_KEY\b" . -S -g '!node_modules'` returns no matches
- `actionlint -color .github/workflows/docker.yml` still reports pre-existing baseline issues in some repos, such as old major action refs and missing `steps.meta` definitions
