### PR TITLE
Add 2026 team members section to TEAM.md

### DIFF
--- a/TEAM.md
+++ b/TEAM.md
@@ -1,5 +1,17 @@
 # Freerooms Team
 
+## 2026
+
+### Leads
+- Ryan Yensch (@RyanYensch)
+
+### Developers
+- Ray Miles (@disarrayx)
+- Christopher Khim (@CrispyKhim)
+- Cormac Flahive (@Cfla446)
+- Caelan Gray (@caelan-g)
+
+
 ## 2025
 
 ### Leads


### PR DESCRIPTION
## What

Added the 2026 web team to the Team.md file

## Why

All Developers should be listed