### PR TITLE
fix: add cursor change to pointer when hovering over building card

### DIFF
--- a/frontend/components/BuildingCard.tsx
+++ b/frontend/components/BuildingCard.tsx
@@ -33,6 +33,7 @@ const MainBox = styled(Box)<BoxProps>(({ theme }) => ({
   [theme.breakpoints.down("md")]: {
     height: 200,
   },
+  cursor: "pointer",
 }));
 
 const ImageBox = styled(Box)<BoxProps>(({ theme }) => ({


### PR DESCRIPTION
## What

Solving 'BUG#1: Mouse not as hand for clickable elements'. 

## Why

The problem is that any part of the building card is clickable, but the mouse does not reflect that and anywhere except for the building image displays the mouse as the pointer. To make clear that the area is interactable/clickable, the cursor should update to a pointer when hovering over any building card.

## How

Added the following line into BuildingCard.tsx within the MainBox function:
" cursor: "pointer", "

## Screenshot / Recording

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/020a2f72-f2ff-4611-92da-150783dc7b48" />

