### PR TITLE
fix: update map height styling to fit the container, removing map overflow

### DIFF
--- a/frontend/components/Map.tsx
+++ b/frontend/components/Map.tsx
@@ -10,6 +10,7 @@ import { DarkModeContext } from "app/clientLayout";
 import React, { useContext, useEffect, useState } from "react";
 import { useDebounceValue } from "usehooks-ts";
 import BuildingDrawer from "views/BuildingDrawer";
+import { navHeight } from "./NavBar";
 
 import { GOOGLE_API_KEY } from "../config";
 import useBuildings from "../hooks/useBuildings";
@@ -84,7 +85,7 @@ export const Map = () => {
 
   const renderMap = () => {
     return (
-      <div style={{ position: "relative", height: "100svh" }}>
+      <div style={{ position: "relative", height: `calc(100svh - ${navHeight}px)` }}>
         <GoogleMap
           mapContainerStyle={{ height: "100%" }}
           center={center}

--- a/frontend/components/Map.tsx
+++ b/frontend/components/Map.tsx
@@ -10,7 +10,6 @@ import { DarkModeContext } from "app/clientLayout";
 import React, { useContext, useEffect, useState } from "react";
 import { useDebounceValue } from "usehooks-ts";
 import BuildingDrawer from "views/BuildingDrawer";
-import { navHeight } from "./NavBar";
 
 import { GOOGLE_API_KEY } from "../config";
 import useBuildings from "../hooks/useBuildings";
@@ -18,6 +17,7 @@ import useUserLocation from "../hooks/useUserLocation";
 import calculateDistance from "../utils/calculateDistance";
 import getMapType from "../utils/getMapType";
 import MapMarker from "./MapMarker";
+import { navHeight } from "./NavBar";
 
 const center = {
   lat: -33.91767,
@@ -85,7 +85,12 @@ export const Map = () => {
 
   const renderMap = () => {
     return (
-      <div style={{ position: "relative", height: `calc(100svh - ${navHeight}px)` }}>
+      <div
+        style={{
+          position: "relative",
+          height: `calc(100svh - ${navHeight}px)`,
+        }}
+      >
         <GoogleMap
           mapContainerStyle={{ height: "100%" }}
           center={center}


### PR DESCRIPTION
## What

Updated the rendered map to fit to the container correctly, removing overflow.

## Why

Originally, the map did not fit the container. This meant the map page had a scrollbar and certain elements were therefore hidden.

## How

Imported the NavBar navHeight constant into Map.tsx and used it to offset the navbar in calculating the proper height of the rendered map.

## Screenshot / Recording

Before:
<img width="1919" height="920" alt="image" src="https://github.com/user-attachments/assets/ffb10053-573c-4e71-a48f-e5b96feab3d4" />


After:
<img width="1919" height="916" alt="image" src="https://github.com/user-attachments/assets/fba4fbe5-460f-4fa7-a821-2f75130e475d" />
