### PR TITLE
fix: all rooms hook using outdated fetch

### DIFF
--- a/frontend/hooks/useAllRooms.ts
+++ b/frontend/hooks/useAllRooms.ts
@@ -7,7 +7,7 @@ import { API_URL } from "../config";
 import { selectDatetime } from "../redux/datetimeSlice";
 import { useSelector } from "../redux/hooks";
 
-const fetcher = (url: string, datetime: Date, filters: AllRoomsFilters) =>
+const fetcher = ([url, datetime, filters]: [string, Date, AllRoomsFilters]) =>
   axios
     .get(url, {
       params: { datetime, ...filters },


### PR DESCRIPTION
## What

Fixed the All Rooms API call to the backend.

## Why

When upgrading packages, the function hook broke and was passing the entire object rather than as params.

## How

Updated the code to meet the newer versions.

## Key checks:

- [x] 🚩**Attached screenshot or recording of the changes in related tickets**
- [x] Code comments where needed
- [x] No new warnings


## Screenshot / Recording

### Before
<img width="760" height="619" alt="image" src="https://github.com/user-attachments/assets/e0d75089-5937-4ff7-be00-56dd13bc1d0f" />

### After
<img width="754" height="744" alt="image" src="https://github.com/user-attachments/assets/fa8f7f5a-0915-4fdc-b4b7-bd496ec0114b" />

