### PR TITLE
fix: updated MapMarker building hover popup with viewport boundary protection

### DIFF
--- a/frontend/components/MapMarker.tsx
+++ b/frontend/components/MapMarker.tsx
@@ -170,14 +170,21 @@ const MarkerHover: React.FC<{
   distance: number | undefined;
   appearLeft?: boolean;
   appearAbove?: boolean;
-}> = ({ building, freerooms, totalRooms, distance, appearLeft = false, appearAbove = false }) => {
+}> = ({
+  building,
+  freerooms,
+  totalRooms,
+  distance,
+  appearLeft = false,
+  appearAbove = false,
+}) => {
   return (
     <MarkerHoverMainBox
       style={{
         left: appearLeft ? "auto" : 0,
         right: appearLeft ? 0 : "auto",
         top: appearAbove ? "auto" : 0,
-        bottom: appearAbove ? 24: "auto"
+        bottom: appearAbove ? 24 : "auto",
       }}
     >
       <MarkerHoverImage

--- a/frontend/components/MapMarker.tsx
+++ b/frontend/components/MapMarker.tsx
@@ -81,6 +81,8 @@ const MapMarker: React.FC<{
 
   const showPopup = currentHover?.id === building?.id;
 
+  const [appearLeft, setAppearLeft] = React.useState(false);
+
   const colour =
     freerooms >= 5 ? "#66bb6a" : freerooms !== 0 ? "#ffa726" : "#f44336";
 
@@ -95,8 +97,14 @@ const MapMarker: React.FC<{
         position: "relative",
         transform: "translate(-50%, -50%)",
       }}
-      onMouseEnter={() => {
+      onMouseEnter={(e) => {
         setCurrentHover(building);
+        const markerScreenPos = e.currentTarget.getBoundingClientRect();
+        if (markerScreenPos.right + 300 > window.innerWidth) {
+          setAppearLeft(true);
+        } else {
+          setAppearLeft(false);
+        }
       }}
       onMouseLeave={() => {
         setCurrentHover(null);
@@ -139,6 +147,7 @@ const MapMarker: React.FC<{
             freerooms={freerooms}
             totalRooms={totalRooms}
             distance={distance}
+            appearLeft={appearLeft}
           />
         </div>
       </Fade>
@@ -151,9 +160,14 @@ const MarkerHover: React.FC<{
   freerooms: number;
   totalRooms: number;
   distance: number | undefined;
-}> = ({ building, freerooms, totalRooms, distance }) => {
+  appearLeft?: boolean;
+}> = ({ building, freerooms, totalRooms, distance, appearLeft = false }) => {
   return (
-    <MarkerHoverMainBox>
+    <MarkerHoverMainBox
+      style={
+        appearLeft ? { right: 0, left: "auto" } : { left: 0, right: "auto" }
+      }
+    >
       <MarkerHoverImage
         alt={`Image of ${building.id}`}
         src={`/assets/building_photos/${building.id}.webp`}

--- a/frontend/components/MapMarker.tsx
+++ b/frontend/components/MapMarker.tsx
@@ -82,6 +82,7 @@ const MapMarker: React.FC<{
   const showPopup = currentHover?.id === building?.id;
 
   const [appearLeft, setAppearLeft] = React.useState(false);
+  const [appearAbove, setAppearAbove] = React.useState(false);
 
   const colour =
     freerooms >= 5 ? "#66bb6a" : freerooms !== 0 ? "#ffa726" : "#f44336";
@@ -100,6 +101,12 @@ const MapMarker: React.FC<{
       onMouseEnter={(e) => {
         setCurrentHover(building);
         const markerScreenPos = e.currentTarget.getBoundingClientRect();
+        if (markerScreenPos.bottom + 200 > window.innerHeight) {
+          setAppearAbove(true);
+        } else {
+          setAppearAbove(false);
+        }
+
         if (markerScreenPos.right + 300 > window.innerWidth) {
           setAppearLeft(true);
         } else {
@@ -148,6 +155,7 @@ const MapMarker: React.FC<{
             totalRooms={totalRooms}
             distance={distance}
             appearLeft={appearLeft}
+            appearAbove={appearAbove}
           />
         </div>
       </Fade>
@@ -161,12 +169,16 @@ const MarkerHover: React.FC<{
   totalRooms: number;
   distance: number | undefined;
   appearLeft?: boolean;
-}> = ({ building, freerooms, totalRooms, distance, appearLeft = false }) => {
+  appearAbove?: boolean;
+}> = ({ building, freerooms, totalRooms, distance, appearLeft = false, appearAbove = false }) => {
   return (
     <MarkerHoverMainBox
-      style={
-        appearLeft ? { right: 0, left: "auto" } : { left: 0, right: "auto" }
-      }
+      style={{
+        left: appearLeft ? "auto" : 0,
+        right: appearLeft ? 0 : "auto",
+        top: appearAbove ? "auto" : 0,
+        bottom: appearAbove ? 0: "auto"
+      }}
     >
       <MarkerHoverImage
         alt={`Image of ${building.id}`}

--- a/frontend/components/MapMarker.tsx
+++ b/frontend/components/MapMarker.tsx
@@ -177,7 +177,7 @@ const MarkerHover: React.FC<{
         left: appearLeft ? "auto" : 0,
         right: appearLeft ? 0 : "auto",
         top: appearAbove ? "auto" : 0,
-        bottom: appearAbove ? 0: "auto"
+        bottom: appearAbove ? 24: "auto"
       }}
     >
       <MarkerHoverImage


### PR DESCRIPTION
## What

Added viewport boundary protection for the MapMarker component so that the hover popup it renders for buildings flips its horizontal and vertical positioning to prevent popup being obscured or overflowing screen edges.

## Why

Originally, the MapMarker hover popup could only render appended to the bottom right of the parent marker. This meant that if a marker was near any of the bottom or right edge of the screen, the popup could flow over the edge of the page, obscuring content.

## How

Introduced local useStates 'appearLeft' and 'appearAbove' into MapMarker. Then inside the onMouseEnter event call of MapMarker a boundary check was implemented using viewport size to determine if the default popup position would pass the viewport size boundary. This then updates the useStates boolean values, which then the values are passed into the MarkerHover component to determine the orientation of the rendered popup to prevent boundary issues.

## Screenshot / Recording

Before:
<img width="1918" height="908" alt="image" src="https://github.com/user-attachments/assets/ac0101af-cb9d-4452-9ab3-29b940513300" />

<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/ac6bb104-5d42-4fdf-a602-e1cec4085045" />


After:
<img width="1912" height="917" alt="image" src="https://github.com/user-attachments/assets/474c35b1-8d25-44d0-b813-f108c48ab95d" />

<img width="1916" height="914" alt="image" src="https://github.com/user-attachments/assets/8343b268-0776-42e7-b812-39ed991b5297" />



