### PR TITLE
824 unable to select time all rooms page

### DIFF
--- a/frontend/__tests__/AllRoomsPage.test.tsx
+++ b/frontend/__tests__/AllRoomsPage.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 
 import { createTheme, ThemeProvider } from "@mui/material";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 
 import AllRoomsFilter from "../components/AllRoomsFilter";
@@ -120,19 +120,19 @@ describe("AllRooms page", () => {
     });
 
     it("allows user to change time in TimePicker", () => {
-      const fixedDate = new Date("2026-06-22T:13:00:00")
+      const fixedDate = new Date("2026-06-22T:13:00:00");
 
-      const { container } = renderWithRedux( <AllRoomsSearchBar/>, {
-        preloadedState: { datetime: { value: fixedDate }},
+      const { container } = renderWithRedux(<AllRoomsSearchBar />, {
+        preloadedState: { datetime: { value: fixedDate } },
       });
 
-      const inputs = container.querySelectorAll('input');
+      const inputs = container.querySelectorAll("input");
 
       // There are only two inputs and the second is the time
       const enterTime = inputs[1];
-      fireEvent.change(enterTime, { target: { value: "02:00 PM"}})
+      fireEvent.change(enterTime, { target: { value: "02:00 PM" } });
 
       expect(enterTime).not.toHaveValue("01:00 PM");
-    })
+    });
   });
 });

--- a/frontend/__tests__/AllRoomsPage.test.tsx
+++ b/frontend/__tests__/AllRoomsPage.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 
 import { createTheme, ThemeProvider } from "@mui/material";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { Provider } from "react-redux";
 
 import AllRoomsFilter from "../components/AllRoomsFilter";
@@ -9,6 +9,7 @@ import Room from "../components/AllRoomsRoom";
 import AllRoomsSearchBar from "../components/AllRoomsSearchBar";
 import NavBar from "../components/NavBar";
 import store from "../redux/store";
+import renderWithRedux from "./utils/renderWithRedux";
 
 describe("AllRooms page", () => {
   it("renders AllRooms top icon", () => {
@@ -117,5 +118,21 @@ describe("AllRooms page", () => {
       expect(room).toBeInTheDocument();
       expect(availability).toBeInTheDocument();
     });
+
+    it("allows user to change time in TimePicker", () => {
+      const fixedDate = new Date("2026-06-22T:13:00:00")
+
+      const { container } = renderWithRedux( <AllRoomsSearchBar/>, {
+        preloadedState: { datetime: { value: fixedDate }},
+      });
+
+      const inputs = container.querySelectorAll('input');
+
+      // There are only two inputs and the second is the time
+      const enterTime = inputs[1];
+      fireEvent.change(enterTime, { target: { value: "02:00 PM"}})
+
+      expect(enterTime).not.toHaveValue("01:00 PM");
+    })
   });
 });

--- a/frontend/components/AllRoomsSearchBar.tsx
+++ b/frontend/components/AllRoomsSearchBar.tsx
@@ -40,7 +40,6 @@ export default function AllRoomsSearchBar() {
             value && dispatch(setDatetime(toSydneyTime(value)))
           }
         />
-        { /* Issue here */ }
         <TimePicker
           label="Start Time"
           defaultValue={datetime}

--- a/frontend/components/AllRoomsSearchBar.tsx
+++ b/frontend/components/AllRoomsSearchBar.tsx
@@ -40,9 +40,10 @@ export default function AllRoomsSearchBar() {
             value && dispatch(setDatetime(toSydneyTime(value)))
           }
         />
+        { /* Issue here */ }
         <TimePicker
           label="Start Time"
-          value={datetime}
+          defaultValue={datetime}
           sx={{ flex: 1 }}
           onAccept={(value: Date | null) =>
             value && dispatch(setDatetime(toSydneyTime(value)))


### PR DESCRIPTION
## What

Fixed the bug where the user couldn't select a time from the dropdown menu in the All Rooms Page.

## Why

To allow users to select the time they want rather than inputting it via their keyboard.

## How

Using `value` would cause the TimePicker to continually use the current time stored in Redux and therefore continuously set the value to that time and not allow any changes. By changing to `defaultValue` it detached the TimePicker from Redux which is fine as it is always set to the current time anyways rather than depending on the state in Redux.

## Key checks:

- [x] 🚩**Attached screenshot or recording of the changes in related tickets**
- [x] Code comments where needed
- [x] No new warnings

## Automated tests:

- [x] 🚩**Unit tests added**

## Manual tests:

- [x] Big Screen (PC Monitor)
- [x] Small Screen (Laptop monitor)

## Screenshot / Recording


https://github.com/user-attachments/assets/f7f5f99f-6d1d-401f-a088-c05f2eb52f22
