### PR TITLE
feat: extend building information menu to MapMarker Popup

### DIFF
--- a/frontend/components/MapMarker.tsx
+++ b/frontend/components/MapMarker.tsx
@@ -168,6 +168,7 @@ const MapMarker: React.FC<{
             distance={distance}
             appearLeft={appearLeft}
             appearAbove={appearAbove}
+            onClick={handleSelectBuilding}
           />
         </div>
       </Fade>
@@ -182,6 +183,7 @@ const MarkerHover: React.FC<{
   distance: number | undefined;
   appearLeft?: boolean;
   appearAbove?: boolean;
+  onClick: () => void;
 }> = ({
   building,
   freerooms,
@@ -189,10 +191,13 @@ const MarkerHover: React.FC<{
   distance,
   appearLeft = false,
   appearAbove = false,
+  onClick,
 }) => {
   return (
     <MarkerHoverMainBox
+      onClick={onClick}
       style={{
+        cursor: "pointer",
         left: appearLeft ? "auto" : 0,
         right: appearLeft ? 0 : "auto",
         top: appearAbove ? "auto" : 0,


### PR DESCRIPTION
## What

extended the handleSelectBuilding logic onClick to the MapMarkerHover.

## Why

Doing this means that the popup is interactable and clicking it creates the same effect as clicking on the map marker itself.

## How

Add an onClick to MarkerHover and an associated change in the icon to a pointer. The onClick leads to the handleSelectBuilding method, which displays the building menu.

## Screenshot / Recording


https://github.com/user-attachments/assets/773a8371-9d62-4dd1-bbe3-3fde7b3113b6

