### PR TITLE
fix: update BookingCalendar time axis to meet earliest booking if earlier than 9am

### DIFF
--- a/frontend/components/BookingCalendar.tsx
+++ b/frontend/components/BookingCalendar.tsx
@@ -175,6 +175,42 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
     setDate(newDate ?? datetime);
   };
 
+  const calendarMin = React.useMemo(() => {
+    const DEFAULT_START_HOUR = 9;
+    const EARLIEST_ALLOWED_HOUR = 5;
+
+    const visibleEvents = events.filter((event) => {
+      if (currView === Views.DAY) {
+        return (
+          event.start.getFullYear() === date.getFullYear() &&
+          event.start.getMonth() === date.getMonth() &&
+          event.start.getDate() === date.getDate()
+        );
+      }
+
+      const weekStart = startOfWeek(date, { weekStartsOn: 1 });
+      const weekEnd = new Date(weekStart);
+      weekEnd.setDate(weekEnd.getDate() + 7);
+
+      return event.end > weekStart && event.start < weekEnd;
+    });
+
+    if (visibleEvents.length === 0) {
+      return new Date(0, 0, 0, DEFAULT_START_HOUR, 0, 0);
+    }
+
+    const earliestStart = visibleEvents.reduce(
+      (earliest, event) => (event.start < earliest ? event.start : earliest),
+      visibleEvents[0].start
+    );
+
+    const startHour = earliestStart.getHours() < DEFAULT_START_HOUR
+        ? Math.max(EARLIEST_ALLOWED_HOUR, earliestStart.getHours())
+        : DEFAULT_START_HOUR;
+
+    return new Date(0, 0, 0, startHour, 0, 0);
+  }, [events, currView, date]);
+
   const { components, getNow, localizer, myEvents, scrollToTime } =
     React.useMemo(() => {
       return {
@@ -190,9 +226,9 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
           locales: enAU,
         }),
         myEvents: events,
-        scrollToTime: datetime,
+        scrollToTime: calendarMin,
       };
-    }, [datetime, events]);
+    }, [datetime, events, calendarMin]);
 
   const formatTime = (
     date: Date,
@@ -360,7 +396,7 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
                 : theme.palette.background.default,
             },
           })}
-          min={new Date(0, 0, 0, 9)}
+          min={calendarMin}
           showMultiDayTimes={true}
           formats={{
             timeGutterFormat: formatTime,

--- a/frontend/components/BookingCalendar.tsx
+++ b/frontend/components/BookingCalendar.tsx
@@ -203,9 +203,10 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
       ...visibleEvents.map((e) => e.start.getHours())
     );
 
-    const startHour = earliestHour < DEFAULT_START_HOUR
-      ? Math.max(EARLIEST_ALLOWED_HOUR, earliestHour)
-      : DEFAULT_START_HOUR;
+    const startHour =
+      earliestHour < DEFAULT_START_HOUR
+        ? Math.max(EARLIEST_ALLOWED_HOUR, earliestHour)
+        : DEFAULT_START_HOUR;
 
     return new Date(0, 0, 0, startHour, 0, 0);
   }, [events, currView, date]);
@@ -227,7 +228,7 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
         myEvents: events,
         scrollToTime: calendarMin,
       };
-    }, [datetime, events, calendarMin]);
+    }, [events, calendarMin]);
 
   const formatTime = (
     date: Date,

--- a/frontend/components/BookingCalendar.tsx
+++ b/frontend/components/BookingCalendar.tsx
@@ -192,21 +192,20 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
       const weekEnd = new Date(weekStart);
       weekEnd.setDate(weekEnd.getDate() + 7);
 
-      return event.end > weekStart && event.start < weekEnd;
+      return event.start >= weekStart && event.start < weekEnd;
     });
 
     if (visibleEvents.length === 0) {
       return new Date(0, 0, 0, DEFAULT_START_HOUR, 0, 0);
     }
 
-    const earliestStart = visibleEvents.reduce(
-      (earliest, event) => (event.start < earliest ? event.start : earliest),
-      visibleEvents[0].start
+    const earliestHour = Math.min(
+      ...visibleEvents.map((e) => e.start.getHours())
     );
 
-    const startHour = earliestStart.getHours() < DEFAULT_START_HOUR
-        ? Math.max(EARLIEST_ALLOWED_HOUR, earliestStart.getHours())
-        : DEFAULT_START_HOUR;
+    const startHour = earliestHour < DEFAULT_START_HOUR
+      ? Math.max(EARLIEST_ALLOWED_HOUR, earliestHour)
+      : DEFAULT_START_HOUR;
 
     return new Date(0, 0, 0, startHour, 0, 0);
   }, [events, currView, date]);

--- a/frontend/components/BookingCalendar.tsx
+++ b/frontend/components/BookingCalendar.tsx
@@ -188,7 +188,7 @@ const BookingCalendar: React.FC<{ events: Array<Booking>; roomID: string }> = ({
         );
       }
 
-      const weekStart = startOfWeek(date, { weekStartsOn: 1 });
+      const weekStart = startOfWeek(date, { weekStartsOn: 0 });
       const weekEnd = new Date(weekStart);
       weekEnd.setDate(weekEnd.getDate() + 7);
 

--- a/frontend/hooks/useFavourites.ts
+++ b/frontend/hooks/useFavourites.ts
@@ -6,6 +6,7 @@ import { useCallback, useSyncExternalStore } from "react";
 // JS compares by reference rather than contents of array.
 let lastStoredFavourites: string | null = null;
 let lastParsedFavourites: string[] = [];
+const empty: string[] = [];
 
 const subscribeToFavourites = (callback: () => void) => {
   const handleStorage = (event: StorageEvent) => {
@@ -34,7 +35,7 @@ const getClientFavouriteSnapshot = (): string[] => {
   return lastParsedFavourites;
 };
 
-const getServerFavouriteSnapshot = (): string[] => [];
+const getServerFavouriteSnapshot = (): string[] => empty;
 
 export default function useFavourites() {
   const favourites = useSyncExternalStore(


### PR DESCRIPTION
## What

Updated BookingCalendar to display the 'min' (the earliest time along the y axis) as a dynamically calculated value depending on the earliest event during that day or week. This value is bounded to be at the earliest 5AM, and at its latest be 9AM.

## Why

Previously, any bookings that occurred before 9AM would not display correctly, e.g. an event from 8AM-9AM would display beginning at 9AM along the axis. Alongside this events that would occur after such an event would visually collide with the previous event even though they shouldn't. 

## How

Used a useMemo to to identify, based on the day/week depending on the view, and if theres no events or the earliest event occurs during/after 9AM, then keep the default 9AM start time for the calendar. Else if an earlier event is found, bound it between 9AM and the earliest allowed time (5AM) and update the minimum time along the calendar axis to this new starting hour. 

*The change to useFavourites was due to a bug in the snapshot cacheing that was occurring in rare cases

## Screenshot / Recording

Before
<img width="1602" height="832" alt="image" src="https://github.com/user-attachments/assets/44db2014-94b9-4507-a179-780c81d9b8b5" />


After
<img width="1583" height="847" alt="image" src="https://github.com/user-attachments/assets/cd96b331-47a4-406e-8e51-2b702e9f4f2c" />

