### PR TITLE
fix: Compare location by id then long rather than just long

### DIFF
--- a/frontend/views/CardList.tsx
+++ b/frontend/views/CardList.tsx
@@ -20,7 +20,6 @@ const FlipMoveGrid = styled(FlipMove)(({ theme }) => ({
   gridGap: "20px",
 }));
 
-
 const getBuildingPosition = (building: Building): number | null => {
   const match = building.id.match(/(\d+)$/);
 
@@ -29,7 +28,7 @@ const getBuildingPosition = (building: Building): number | null => {
   }
 
   return Number(match[1]);
-}
+};
 
 const compareBuildingPosition = (
   a: Building,
@@ -64,8 +63,7 @@ const compareBuildingPosition = (
   }
 
   return a.name.localeCompare(b.name);
-}
-
+};
 
 const FlippableCard = React.forwardRef<HTMLDivElement, { buildingId: string }>(
   ({ buildingId }, ref) => {

--- a/frontend/views/CardList.tsx
+++ b/frontend/views/CardList.tsx
@@ -20,6 +20,53 @@ const FlipMoveGrid = styled(FlipMove)(({ theme }) => ({
   gridGap: "20px",
 }));
 
+
+const getBuildingPosition = (building: Building): number | null => {
+  const match = building.id.match(/(\d+)$/);
+
+  if (!match) {
+    return null;
+  }
+
+  return Number(match[1]);
+}
+
+const compareBuildingPosition = (
+  a: Building,
+  b: Building,
+  direction: "lowerToUpper" | "upperToLower"
+): number => {
+  const aPosition = getBuildingPosition(a);
+  const bPosition = getBuildingPosition(b);
+
+  if (aPosition == null && bPosition == null) {
+    return a.name.localeCompare(b.name);
+  }
+
+  if (aPosition == null) {
+    return 1;
+  }
+
+  if (bPosition == null) {
+    return -1;
+  }
+
+  const positionDiff = aPosition - bPosition;
+
+  if (positionDiff !== 0) {
+    return direction === "lowerToUpper" ? positionDiff : -positionDiff;
+  }
+
+  const longDiff = a.long - b.long;
+
+  if (longDiff !== 0) {
+    return direction === "lowerToUpper" ? longDiff : -longDiff;
+  }
+
+  return a.name.localeCompare(b.name);
+}
+
+
 const FlippableCard = React.forwardRef<HTMLDivElement, { buildingId: string }>(
   ({ buildingId }, ref) => {
     const displayMobile = useMediaQuery(useTheme().breakpoints.down("sm"));
@@ -59,9 +106,9 @@ const CardList: React.FC<{
       .sort((a, b) => {
         switch (sort) {
           case "lowerToUpper":
-            return a.long - b.long;
+            return compareBuildingPosition(a, b, "lowerToUpper");
           case "upperToLower":
-            return b.long - a.long;
+            return compareBuildingPosition(a, b, "upperToLower");
           case "nearest":
             return userLat && userLng
               ? calculateDistance(userLat, userLng, a.lat, a.long) -


### PR DESCRIPTION
## What

Sorted the lower-to-upper campus by building ID, then by longitude, then by name, rather than just longitude.

## Why

There are 3 buildings for which we do not have the location data but do have the ID for, so it was comparing by 0 and placing those buildings in the wrong location.

## How

Got the ID for the room (e.g. K-D17 becomes 17) and used that as the main comparator; if they have the same ID, it then uses the longitude to determine which is higher/lower; if somehow they are identical, it then does it alphabetically for the building name.

## Key checks:

- [x] 🚩**Attached screenshot or recording of the changes in related tickets**
- [x] No new warnings


## Manual tests:

- [x] Big Screen (PC Monitor)
- [x] Small Screen (Laptop monitor)

## Screenshot / Recording

### Before (prod)
#### Lower sort
<img width="1525" height="479" alt="image" src="https://github.com/user-attachments/assets/920a374b-548a-4e81-ac4a-9d69e25fd1d1" />

#### Upper sort
<img width="1894" height="850" alt="image" src="https://github.com/user-attachments/assets/e2a70fdc-66eb-484e-8c33-56f706601d64" />

### After
#### Lower Sort
<img width="1894" height="798" alt="image" src="https://github.com/user-attachments/assets/a39f92c4-2922-4fd3-833c-0e0646014ec6" />

#### Upper sort
<img width="1894" height="798" alt="image" src="https://github.com/user-attachments/assets/5e5a18b3-618f-42bc-995f-7993641941b6" />

#### Upper Sort